### PR TITLE
Fix pytorch version to match DLC container (1.13.1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,8 @@ locals {
     "1.8.1-cpu" = "1.8.1-transformers${var.transformers_version}-cpu-py36-ubuntu18.04"
     "1.9.1-gpu" = "1.9.1-transformers${var.transformers_version}-gpu-py38-cu111-ubuntu20.04"
     "1.9.1-cpu" = "1.9.1-transformers${var.transformers_version}-cpu-py38-ubuntu20.04"
-    "1.13-cpu" = "1.13-transformers${var.transformers_version}-cpu-py39-ubuntu20.04"
-    "1.13-gpu" = "1.13-transformers${var.transformers_version}-gpu-py39-cu117-ubuntu20.04"
+    "1.13.1-cpu" = "1.13.1-transformers${var.transformers_version}-cpu-py39-ubuntu20.04"
+    "1.13.1-gpu" = "1.13.1-transformers${var.transformers_version}-gpu-py39-cu117-ubuntu20.04"
   }
   tensorflow_image_tag = {
     "2.4.1-gpu" = "2.4.1-transformers${var.transformers_version}-gpu-py37-cu110-ubuntu18.04"


### PR DESCRIPTION
Per https://huggingface.co/docs/sagemaker/reference#inference-dlc-overview and https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-inference-containers it looks like there's only an ECR image for 1.13.1.

Running this script with 1.13 gives the following TF error:

```
│ Error: creating SageMaker model: ValidationException: Requested image 763104351884.dkr.ecr.us-west-2.amazonaws.com/huggingface-pytorch-inference:1.13-transformers4.26.0-cpu-py39-ubuntu20.04 not found.
│ 	status code: 400, request id: SNIP
```