### PR TITLE
bump aws requirement to ~> 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 1.3.0"


### PR DESCRIPTION
Per https://github.com/philschmid/terraform-aws-sagemaker-huggingface/issues/16#issuecomment-1634121024

Have done very limited testing, but seems to work.

```
module "example" {
  source               = "philschmid/sagemaker-huggingface/aws"
  version              = "x.y.z"
  name_prefix          = "test"
  pytorch_version      = "1.13.1"
  transformers_version = "4.26.0"
  instance_type        = "ml.g4dn.xlarge"
  instance_count       = 1
  hf_model_id          = "nvidia/segformer-b0-finetuned-ade-512-512"
  hf_task              = "image-segmentation"
}
```