### PR TITLE
feat: adding a variable for controlling the autoscaling predefined metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ module "sagemaker-huggingface" {
   hf_model_id          = "distilbert-base-uncased-finetuned-sst-2-english"
   hf_task              = "text-classification"
   autoscaling = {
-    max_capacity               = 4   # The max capacity of the scalable target
-    scaling_target_invocations = 200 # The scaling target invocations (requests/minute)
+    max_capacity = 4   # The max capacity of the scalable target
+    target_value = 200 # The scaling target invocations (requests/minute)
   }
 }
 ```
@@ -92,7 +92,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_async_config"></a> [async\_config](#input\_async\_config) | (Optional) Specifies configuration for how an endpoint performs asynchronous inference. Required key is `s3_output_path`, which is the s3 bucket used for async inference. | <pre>object({<br>    s3_output_path    = string,<br>    kms_key_id        = optional(string),<br>    sns_error_topic   = optional(string),<br>    sns_success_topic = optional(string),<br>  })</pre> | <pre>{<br>  "kms_key_id": null,<br>  "s3_output_path": null,<br>  "sns_error_topic": null,<br>  "sns_success_topic": null<br>}</pre> | no |
-| <a name="input_autoscaling"></a> [autoscaling](#input\_autoscaling) | A Object which defines the autoscaling target and policy for our SageMaker Endpoint. Required keys are `max_capacity` and `scaling_target_invocations` | <pre>object({<br>    min_capacity               = optional(number),<br>    max_capacity               = number,<br>    scaling_target_invocations = optional(number),<br>    scale_in_cooldown          = optional(number),<br>    scale_out_cooldown         = optional(number),<br>  })</pre> | <pre>{<br>  "max_capacity": null,<br>  "min_capacity": 1,<br>  "scale_in_cooldown": 300,<br>  "scale_out_cooldown": 66,<br>  "scaling_target_invocations": null<br>}</pre> | no |
+| <a name="input_autoscaling"></a> [autoscaling](#input\_autoscaling) | An Object which defines the autoscaling target and policy for our SageMaker Endpoint. Required key is `max_capacity` | <pre>object({<br>    min_capacity               = optional(number),<br>    max_capacity               = number,<br>    target_value = optional(number),<br>    scale_in_cooldown          = optional(number),<br>    scale_out_cooldown         = optional(number),<br>  })</pre> | <pre>{<br>  "max_capacity": null,<br>  "min_capacity": 1,<br>  "scale_in_cooldown": 300,<br>  "scale_out_cooldown": 66,<br>  "target_value": null<br>}</pre> | no |
 | <a name="input_hf_api_token"></a> [hf\_api\_token](#input\_hf\_api\_token) | The HF\_API\_TOKEN environment variable defines the your Hugging Face authorization token. The HF\_API\_TOKEN is used as a HTTP bearer authorization for remote files, like private models. You can find your token at your settings page. | `string` | `null` | no |
 | <a name="input_hf_model_id"></a> [hf\_model\_id](#input\_hf\_model\_id) | The HF\_MODEL\_ID environment variable defines the model id, which will be automatically loaded from [hf.co/models](https://huggingface.co/models) when creating or SageMaker Endpoint. | `string` | `null` | no |
 | <a name="input_hf_model_revision"></a> [hf\_model\_revision](#input\_hf\_model\_revision) | The HF\_MODEL\_REVISION is an extension to HF\_MODEL\_ID and allows you to define/pin a revision of the model to make sure you always load the same model on your SageMaker Endpoint. | `string` | `null` | no |

--- a/examples/async_inference/README.md
+++ b/examples/async_inference/README.md
@@ -25,9 +25,10 @@ module "huggingface_sagemaker" {
     # sns_success_topic = "arn:aws:sns:aws-region:account-id:topic-name"
   }
   autoscaling = {
-    min_capacity               = 0
-    max_capacity               = 4
-    scaling_target_invocations = 100
+    min_capacity           = 0
+    max_capacity           = 4
+    target_value           = 100
+    predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
   }
 }
 ```

--- a/examples/async_inference/main.tf
+++ b/examples/async_inference/main.tf
@@ -30,8 +30,9 @@ module "huggingface_sagemaker" {
     # sns_success_topic = "arn:aws:sns:aws-region:account-id:topic-name"
   }
   autoscaling = {
-    min_capacity               = 0
-    max_capacity               = 4
-    scaling_target_invocations = 100
+    min_capacity           = 0
+    max_capacity           = 1
+    target_value           = 0.5
+    predefined_metric_type = "HasBacklogWithoutCapacity"
   }
 }

--- a/examples/autoscaling_example/README.md
+++ b/examples/autoscaling_example/README.md
@@ -12,11 +12,11 @@ module "huggingface_sagemaker" {
   hf_model_id          = "distilbert-base-uncased-finetuned-sst-2-english"
   hf_task              = "text-classification"
   autoscaling = {
-    min_capacity               = 1   # The min capacity of the scalable target, default is 1
-    max_capacity               = 4   # The max capacity of the scalable target
-    scaling_target_invocations = 200 # The scaling target invocations (requests/minute)
-    scale_in_cooldown          = 300 # The cooldown time after scale-in, default is 300
-    scale_out_cooldown         = 60  # The cooldown time after scale-out, default is 60
+    min_capacity       = 1   # The min capacity of the scalable target, default is 1
+    max_capacity       = 4   # The max capacity of the scalable target
+    target_value       = 200 # The scaling target invocations (requests/minute)
+    scale_in_cooldown  = 300 # The cooldown time after scale-in, default is 300
+    scale_out_cooldown = 60  # The cooldown time after scale-out, default is 60
   }
 }
 ```

--- a/examples/autoscaling_example/main.tf
+++ b/examples/autoscaling_example/main.tf
@@ -17,10 +17,11 @@ module "huggingface_sagemaker" {
   hf_model_id          = "distilbert-base-uncased-finetuned-sst-2-english"
   hf_task              = "text-classification"
   autoscaling = {
-    min_capacity               = 1   # The min capacity of the scalable target, default is 1
-    max_capacity               = 4   # The max capacity of the scalable target
-    scaling_target_invocations = 200 # The scaling target invocations (requests/minute)
-    scale_in_cooldown          = 300 # The cooldown time after scale-in, default is 300
-    scale_out_cooldown         = 60  # The cooldown time after scale-out, default is 60
+    min_capacity           = 1   # The min capacity of the scalable target, default is 1
+    max_capacity           = 4   # The max capacity of the scalable target
+    target_value           = 200 # The scaling target invocations (requests/minute)
+    scale_in_cooldown      = 300 # The cooldown time after scale-in, default is 300
+    scale_out_cooldown     = 60  # The cooldown time after scale-out, default is 60
+    predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -246,7 +246,7 @@ resource "aws_sagemaker_endpoint" "huggingface" {
 
 
 locals {
-  use_autoscaling = var.autoscaling.max_capacity != null && var.autoscaling.scaling_target_invocations != null && !local.sagemaker_endpoint_type.serverless ? 1 : 0
+  use_autoscaling = var.autoscaling.max_capacity != null && var.autoscaling.target_value != null && !local.sagemaker_endpoint_type.serverless ? 1 : 0
 }
 
 resource "aws_appautoscaling_target" "sagemaker_target" {
@@ -268,9 +268,9 @@ resource "aws_appautoscaling_policy" "sagemaker_policy" {
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
-      predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
+      predefined_metric_type = var.autoscaling.predefined_metric_type
     }
-    target_value       = var.autoscaling.scaling_target_invocations
+    target_value       = var.autoscaling.target_value
     scale_in_cooldown  = var.autoscaling.scale_in_cooldown
     scale_out_cooldown = var.autoscaling.scale_out_cooldown
   }

--- a/variables.tf
+++ b/variables.tf
@@ -80,21 +80,23 @@ variable "sagemaker_execution_role" {
 }
 
 variable "autoscaling" {
-  description = "A Object which defines the autoscaling target and policy for our SageMaker Endpoint. Required keys are `max_capacity` and `scaling_target_invocations` "
+  description = "A Object which defines the autoscaling target and policy for our SageMaker Endpoint. Required key is `max_capacity`"
   type = object({
-    min_capacity               = optional(number),
-    max_capacity               = number,
-    scaling_target_invocations = optional(number),
-    scale_in_cooldown          = optional(number),
-    scale_out_cooldown         = optional(number),
+    min_capacity           = optional(number),
+    max_capacity           = number,
+    target_value           = optional(number),
+    scale_in_cooldown      = optional(number),
+    scale_out_cooldown     = optional(number),
+    predefined_metric_type = optional(string)
   })
 
   default = {
-    min_capacity               = 1
-    max_capacity               = null
-    scaling_target_invocations = null
-    scale_in_cooldown          = 300
-    scale_out_cooldown         = 66
+    min_capacity           = 1
+    max_capacity           = null
+    target_value           = null
+    scale_in_cooldown      = 300
+    scale_out_cooldown     = 66
+    predefined_metric_type = "SageMakerVariantInvocationsPerInstance"
   }
 }
 


### PR DESCRIPTION
- Added autoscaling predefined metric as variable with a default value of "SageMakerVariantInvocationsPerInstance".
- Changed the naming of scaling_target_invocations to target_value as this variable now serves the target value of more than one metric.
- Adjusted docs and examples.